### PR TITLE
perf: Remove intermediate ToList in AllowedThingDefsPostfix

### DIFF
--- a/Source/EBSGFramework/HarmonyPatches.cs
+++ b/Source/EBSGFramework/HarmonyPatches.cs
@@ -917,12 +917,7 @@ namespace EBSGFramework
 
         public static void AllowedThingDefsPostfix(ref IEnumerable<ThingDef> __result)
         {
-            if (__result.EnumerableNullOrEmpty()) 
-                return;
-            List<ThingDef> invalidThings = __result.Where(t => !t.comps.NullOrEmpty()).Where(th => th.comps.OfType<CompProperties_Indestructible>().Any()).ToList();
-
-            if (!invalidThings.NullOrEmpty())
-                __result = __result.Where(t => !invalidThings.Contains(t));
+            __result = __result.Where(def => def.GetCompProperties<CompProperties_Indestructible>() == null);
         }
 
         public static void CostToMoveIntoCellPostfix(Pawn pawn, IntVec3 c, ref float __result)


### PR DESCRIPTION
Discovered this while trying to figure out severe frame drops when this mod is used alongside ["Nice Bill Tab"](https://steamcommunity.com/sharedfiles/filedetails/?id=3520130671).

The change simplifies the logic of the patch to just apply an additional filter instead of creating a list to filter. This greatly improves performances.

I tested that change in my personal mod and works as expected (I was able to pinpoint the actual reason of the performances issues in "Nice Bill Tab" thanks to it).

I was however not able to compile this project to test that change here (I use linux and mono is just not cooperating half the time).