### PR TITLE
Add optional barColor to HediffCompProperties_Shield for a customizable charge-gizmo bar

### DIFF
--- a/Source/EBSGFramework/Hediffs/CompProperties/HediffCompProperties_Shield.cs
+++ b/Source/EBSGFramework/Hediffs/CompProperties/HediffCompProperties_Shield.cs
@@ -59,6 +59,8 @@ namespace EBSGFramework
         public bool displayGizmo = true;
         public string gizmoTitle;
         public string gizmoTip;
+        // Custom fill colour for the charge gizmo's bar
+        public Color? barColor;
 
         // Shield scale based on amount of energy left
         public float minDrawSize = 1.2f;

--- a/Source/EBSGFramework/Hediffs/Gizmo_HediffShieldStatus.cs
+++ b/Source/EBSGFramework/Hediffs/Gizmo_HediffShieldStatus.cs
@@ -1,4 +1,5 @@
-﻿using UnityEngine;
+﻿using System.Collections.Generic;
+using UnityEngine;
 using Verse;
 
 namespace EBSGFramework
@@ -10,6 +11,23 @@ namespace EBSGFramework
 
         public static readonly Texture2D FullShieldBarTex = SolidColorMaterials.NewSolidColorTexture(new Color(0.2f, 0.2f, 0.24f));
         public static readonly Texture2D EmptyShieldBarTex = SolidColorMaterials.NewSolidColorTexture(Color.clear);
+
+        private static readonly Dictionary<Color, Texture2D> customBarTexCache = new Dictionary<Color, Texture2D>();
+
+        private Texture2D FillTex
+        {
+            get
+            {
+                if (!shieldComp.Props.barColor.HasValue) return FullShieldBarTex;
+                Color color = shieldComp.Props.barColor.Value;
+                if (!customBarTexCache.TryGetValue(color, out Texture2D tex))
+                {
+                    tex = SolidColorMaterials.NewSolidColorTexture(color);
+                    customBarTexCache[color] = tex;
+                }
+                return tex;
+            }
+        }
 
         public Gizmo_HediffShieldStatus(HediffComp_Shield comp)
         {
@@ -35,7 +53,7 @@ namespace EBSGFramework
             Rect barRect = drawRect;
             barRect.yMin = drawRect.y + drawRect.height / 2f;
             float num = shieldComp.energy / Mathf.Max(1f, shieldComp.MaxEnergy);
-            Widgets.FillableBar(barRect, num, FullShieldBarTex, EmptyShieldBarTex, false);
+            Widgets.FillableBar(barRect, num, FillTex, EmptyShieldBarTex, false);
             Text.Font = GameFont.Small;
             Widgets.Label(barRect, (shieldComp.energy * 100f).ToString("F0") + " / " + (shieldComp.MaxEnergy * 100f).ToString("F0"));
             Text.Anchor = TextAnchor.UpperLeft;


### PR DESCRIPTION
Added `barColor` as an optional property for Shield, letting you set a custom fill colour for the charge bar and defaulting to the vanilla grey if it's not set. I'm a noob though so I'm not sure if this would have ... deadly consequences. I was messing around with a psychic shield and thought it'd be cool if the charge bar was green. In testing it worked ¯\_(ツ)_/¯. 